### PR TITLE
Advance LastReconnectTicks before restoring subscribers, fixes #11

### DIFF
--- a/StackExchange.Redis.Resilience/Async/ResilientConnectionMultiplexer.cs
+++ b/StackExchange.Redis.Resilience/Async/ResilientConnectionMultiplexer.cs
@@ -92,8 +92,7 @@ namespace StackExchange.Redis.Resilience
                         return false;
                     }
 
-                    await (SetupMultiplexerAsync(newMultiplexer, _connectionMultiplexer, cancellationToken)).ConfigureAwait(false);
-                    Interlocked.Exchange(ref _lastReconnectTicks, utcNow.UtcTicks);
+                    await (SetupMultiplexerAsync(newMultiplexer, _connectionMultiplexer, utcNow.UtcTicks, cancellationToken)).ConfigureAwait(false);
 
                     return true;
                 }
@@ -104,10 +103,12 @@ namespace StackExchange.Redis.Resilience
             }
         }
 
-        private async Task SetupMultiplexerAsync(IConnectionMultiplexer newMultiplexer, IConnectionMultiplexer oldMultiplexer, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task SetupMultiplexerAsync(IConnectionMultiplexer newMultiplexer, IConnectionMultiplexer oldMultiplexer, long reconnectTicks, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
             _connectionMultiplexer = newMultiplexer;
+            // Signal the reconnect as soon as the new multiplexer is set, so that already resolved instances can rebind to it
+            Interlocked.Exchange(ref _lastReconnectTicks, reconnectTicks);
             CloseMultiplexer(oldMultiplexer);
 
             // Copy properties that have a setter

--- a/StackExchange.Redis.Resilience/ResilientConnectionMultiplexer.cs
+++ b/StackExchange.Redis.Resilience/ResilientConnectionMultiplexer.cs
@@ -19,6 +19,8 @@ namespace StackExchange.Redis.Resilience
     /// done after the batch was created.</para>
     /// <para>- Enumerating a collection from IDatabase.SetScan, IDatabase.HashScan and IDatabase.SortedSetScan methods
     /// may throw an <see cref="ObjectDisposedException"/> when a reconnect was done while iterating the collection.</para>
+    /// <para>Calls made directly on an <see cref="IDatabase"/>, <see cref="IServer"/> or <see cref="ISubscriber"/> are
+    /// rebound on reconnect, so those instances are safe to cache.</para>
     /// </summary>
     public partial class ResilientConnectionMultiplexer : IResilientConnectionMultiplexer
     {
@@ -306,8 +308,7 @@ namespace StackExchange.Redis.Resilience
                     return false;
                 }
 
-                SetupMultiplexer(newMultiplexer, _connectionMultiplexer);
-                Interlocked.Exchange(ref _lastReconnectTicks, utcNow.UtcTicks);
+                SetupMultiplexer(newMultiplexer, _connectionMultiplexer, utcNow.UtcTicks);
 
                 return true;
             }
@@ -358,9 +359,11 @@ namespace StackExchange.Redis.Resilience
             return false;
         }
 
-        private void SetupMultiplexer(IConnectionMultiplexer newMultiplexer, IConnectionMultiplexer oldMultiplexer)
+        private void SetupMultiplexer(IConnectionMultiplexer newMultiplexer, IConnectionMultiplexer oldMultiplexer, long reconnectTicks)
         {
             _connectionMultiplexer = newMultiplexer;
+            // Signal the reconnect as soon as the new multiplexer is set, so that already resolved instances can rebind to it
+            Interlocked.Exchange(ref _lastReconnectTicks, reconnectTicks);
             CloseMultiplexer(oldMultiplexer);
 
             // Copy properties that have a setter
@@ -594,6 +597,11 @@ namespace StackExchange.Redis.Resilience
 
                 action();
             }
+            catch (ObjectDisposedException)
+            {
+                // The reconnect already happened, retrying is enough for the action to rebind to the new multiplexer
+                action();
+            }
         }
 
         internal static T ExecuteAction<T>(IResilientConnectionMultiplexer resilientConnectionMultiplexer, Func<T> action)
@@ -610,6 +618,11 @@ namespace StackExchange.Redis.Resilience
                     throw;
                 }
 
+                return action();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The reconnect already happened, retrying is enough for the action to rebind to the new multiplexer
                 return action();
             }
         }
@@ -630,6 +643,11 @@ namespace StackExchange.Redis.Resilience
 
                 await action().ConfigureAwait(false);
             }
+            catch (ObjectDisposedException)
+            {
+                // The reconnect already happened, retrying is enough for the action to rebind to the new multiplexer
+                await action().ConfigureAwait(false);
+            }
         }
 
         internal static async Task<T> ExecuteActionAsync<T>(IResilientConnectionMultiplexer resilientConnectionMultiplexer, Func<Task<T>> action)
@@ -646,6 +664,11 @@ namespace StackExchange.Redis.Resilience
                     throw;
                 }
 
+                return await action().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The reconnect already happened, retrying is enough for the action to rebind to the new multiplexer
                 return await action().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
Fixes #11.

## Changes

- Move the `LastReconnectTicks` bump to right after the multiplexer field swap in `SetupMultiplexer` / `SetupMultiplexerAsync`, before disposing the old connection and before restoring subscribers.
- Add a retry on `ObjectDisposedException` to the four `ExecuteAction`/`ExecuteActionAsync` helpers, as its own catch clause rather than widening the existing `RedisConnectionException`/`SocketException` one - necessary because `TryReconnect`/`TryReconnectAsync` always returns `false` on the call right after a reconnect, so a widened `when` would rethrow instead of retrying.

## Why this is safe

`LastReconnectTicks` has one consumer, `CheckAndReset`, and its only effect is re-resolving a proxy against `_connectionMultiplexer` - the field that was just swapped. So the tick and the state it signals are one line apart - moving the bump earlier makes the signal more accurate.

A potential additional issue: `PopulateSubscribers` has a pre-existing, unrelated race condition (it enumerates `_subscriptions` while `AddSubscription` can mutate it concurrently, without a lock). A cached subscriber can't reach that race condition currently because it gets short circuited by `ObjectDisposedException` first - this fix prevents the exception being reached, which now exposes this race condition. Calling it out rather than fixing it here, since it's a separate bug and this PR is scoped to the reconnect ordering.

## Testing

Existing suite passes unchanged. Repro app linked from #11 shows the fix working against a real Redis - see the issue for the before/after numbers.